### PR TITLE
Add make vmlib command

### DIFF
--- a/docs/4-running-iost-node/Deployment.md
+++ b/docs/4-running-iost-node/Deployment.md
@@ -18,6 +18,7 @@ Run the command to compile and generate file in the `target` directory:
 
 ```
 git checkout v2.0.0
+make vmlib
 make build
 ```
 

--- a/website/versioned_docs/version-1.0.4/4-running-iost-node/Deployment.md
+++ b/website/versioned_docs/version-1.0.4/4-running-iost-node/Deployment.md
@@ -18,6 +18,7 @@ git clone git@github.com:iost-official/go-iost.git
 Run the command to compile and generate file in the `target` directory:
 
 ```
+make vmlib
 make build
 ```
 

--- a/website/versioned_docs/version-1.0.6/4-running-iost-node/Deployment.md
+++ b/website/versioned_docs/version-1.0.6/4-running-iost-node/Deployment.md
@@ -18,6 +18,7 @@ git clone git@github.com:iost-official/go-iost.git
 Run the command to compile and generate file in the `target` directory:
 
 ```
+make vmlib
 make build
 ```
 

--- a/website/versioned_docs/version-2.0.1/4-running-iost-node/Deployment.md
+++ b/website/versioned_docs/version-2.0.1/4-running-iost-node/Deployment.md
@@ -19,6 +19,7 @@ Run the command to compile and generate file in the `target` directory:
 
 ```
 git checkout v2.0.0
+make vmlib
 make build
 ```
 


### PR DESCRIPTION
In OS X, there is some issue when you skip `make vmlib`.
`make vmlib` is necessary before `make build`.
I added `make vmlib` command in **Deploy** section.