### PR TITLE
Fix typo 'anme' to 'name'

### DIFF
--- a/docs/7-iost-js/Blockchain.md
+++ b/docs/7-iost-js/Blockchain.md
@@ -312,7 +312,7 @@ get account info from blockchain
 ### Parameters
 Name             |Type       |Description 
 ----                |--         |--
-anme 		|String          | account name
+name 		|String          | account name
 by_longest_chain 	|Boolean 		 | get account by longest chain's head block or last irreversible block
 
 ### Returns

--- a/website/translated_docs/ko/7-iost-js/Blockchain.md
+++ b/website/translated_docs/ko/7-iost-js/Blockchain.md
@@ -312,7 +312,7 @@ get account info from blockchain
 ### Parameters
 Name             |Type       |Description 
 ----                |--         |--
-anme 		|String          | account name
+name 		|String          | account name
 by_longest_chain 	|Boolean 		 | get account by longest chain's head block or last irreversible block
 
 ### Returns

--- a/website/translated_docs/ko/version-2.0.2/7-iost-js/Blockchain.md
+++ b/website/translated_docs/ko/version-2.0.2/7-iost-js/Blockchain.md
@@ -312,7 +312,7 @@ get account info from blockchain
 ### Parameters
 Name             |Type       |Description 
 ----                |--         |--
-anme 		|String          | account name
+name 		|String          | account name
 by_longest_chain 	|Boolean 		 | get account by longest chain's head block or last irreversible block
 
 ### Returns

--- a/website/translated_docs/zh-CN/version-2.0.2/7-iost-js/Blockchain.md
+++ b/website/translated_docs/zh-CN/version-2.0.2/7-iost-js/Blockchain.md
@@ -312,7 +312,7 @@ get account info from blockchain
 ### Parameters
 Name             |Type       |Description 
 ----                |--         |--
-anme 		|String          | account name
+name 		|String          | account name
 by_longest_chain 	|Boolean 		 | get account by longest chain's head block or last irreversible block
 
 ### Returns

--- a/website/versioned_docs/version-2.0.2/7-iost-js/Blockchain.md
+++ b/website/versioned_docs/version-2.0.2/7-iost-js/Blockchain.md
@@ -313,7 +313,7 @@ get account info from blockchain
 ### Parameters
 Name             |Type       |Description 
 ----                |--         |--
-anme 		|String          | account name
+name 		|String          | account name
 by_longest_chain 	|Boolean 		 | get account by longest chain's head block or last irreversible block
 
 ### Returns


### PR DESCRIPTION
There is a typo 'anme'. 
It should be fixed to 'name'.