### PR TITLE
Fix 'make deploy' keyword to 'make vmlib'

### DIFF
--- a/docs/3-smart-contract/Environment-setup.md
+++ b/docs/3-smart-contract/Environment-setup.md
@@ -31,5 +31,5 @@ npm install
 
 ```git
 cd go-iost
-make deploy
+make vmlib
 ```

--- a/website/translated_docs/ko/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/ko/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 ## ```Dynamic Library``` 설치하기
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/translated_docs/ko/version-1.0.4/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/ko/version-1.0.4/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 ## ```Dynamic Library``` 설치하기
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/translated_docs/ko/version-1.0.6/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/ko/version-1.0.6/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 ## ```Dynamic Library``` 설치하기
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/translated_docs/ko/version-1.0.7/1-getting-started/Environment-setup.md
+++ b/website/translated_docs/ko/version-1.0.7/1-getting-started/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 ## ```Dynamic Library``` 설치하기
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/translated_docs/ko/version-1.0.7/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/ko/version-1.0.7/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 ## ```Dynamic Library``` 설치하기
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/translated_docs/ko/version-2.0.3/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/ko/version-2.0.3/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 ## ```Dynamic Library``` 설치하기
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/translated_docs/zh-CN/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/zh-CN/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 
 ```git
 cd go-iost
-make deploy
+make vmlib
 ```
 

--- a/website/translated_docs/zh-CN/version-1.0.7/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/zh-CN/version-1.0.7/3-smart-contract/Environment-setup.md
@@ -29,7 +29,7 @@ npm install
 ## 安装 `Dynamic Lib` 依赖
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```
 

--- a/website/translated_docs/zh-CN/version-2.0.3/3-smart-contract/Environment-setup.md
+++ b/website/translated_docs/zh-CN/version-2.0.3/3-smart-contract/Environment-setup.md
@@ -30,6 +30,6 @@ npm install
 
 ```git
 cd go-iost
-make deploy
+make vmlib
 ```
 

--- a/website/versioned_docs/version-1.0.7/3-smart-contract/Environment-setup.md
+++ b/website/versioned_docs/version-1.0.7/3-smart-contract/Environment-setup.md
@@ -31,6 +31,6 @@ npm install
 ## Install```Dynamic Library```
 
 ```git
-cd go-iost/vm/v8vm/v8
-make deploy
+cd go-iost
+make vmlib
 ```

--- a/website/versioned_docs/version-2.0.3/3-smart-contract/Environment-setup.md
+++ b/website/versioned_docs/version-2.0.3/3-smart-contract/Environment-setup.md
@@ -32,5 +32,5 @@ npm install
 
 ```git
 cd go-iost
-make deploy
+make vmlib
 ```


### PR DESCRIPTION
`$ make deploy` was deprecated keyword according to `Makefile` file.
It should be fixed to `$ make vmlib` to install dynamic vm library.

And, since `$ make vmlib` already do following commands
```
  (cd vm/v8vm/v8/; make clean js_bin vm install deploy; cd ../../..)
```.

It's ok to remove the command `cd vm/v8vm/v8/` on the document.